### PR TITLE
FAT2-169 - Change timeout for CD Client

### DIFF
--- a/src/SFA.DAS.CourseDelivery.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.CourseDelivery.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -21,7 +21,10 @@ namespace SFA.DAS.CourseDelivery.Api.AppStart
             }
             else
             {
-                services.AddHttpClient<ICourseDirectoryService, CourseDirectoryService>()
+                services.AddHttpClient<ICourseDirectoryService, CourseDirectoryService>
+                    (
+                        options=> options.Timeout = TimeSpan.FromMinutes(10)
+                    )
                     .SetHandlerLifetime(TimeSpan.FromMinutes(10))
                     .AddPolicyHandler(GetCourseDirectoryRetryPolicy());    
             }


### PR DESCRIPTION
Changed the default timeout for the course directory client to be 10 minutes due to it being a long running operation